### PR TITLE
Fix platform detection for YouTube profile links

### DIFF
--- a/app/components/campaigns/keyword-search/utils/profile-link.ts
+++ b/app/components/campaigns/keyword-search/utils/profile-link.ts
@@ -5,6 +5,134 @@ const YOUTUBE_HANDLE_BASE = 'https://www.youtube.com/';
 const TIKTOK_BASE = 'https://www.tiktok.com/@';
 const INSTAGRAM_BASE = 'https://www.instagram.com/';
 
+function normalizePlatformValue(value: unknown): 'youtube' | 'instagram' | 'tiktok' | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const lowered = trimmed.toLowerCase();
+  const compact = lowered.replace(/[\s-]+/g, '_');
+
+  if (compact.startsWith('youtube') || compact === 'yt') {
+    return 'youtube';
+  }
+
+  if (compact.startsWith('instagram') || compact === 'ig' || compact.includes('enhanced_instagram')) {
+    return 'instagram';
+  }
+
+  if (compact.startsWith('tiktok') || compact === 'tt' || compact.includes('douyin')) {
+    return 'tiktok';
+  }
+
+  return null;
+}
+
+function hasYouTubeIndicators(creator: any): boolean {
+  const channelIdCandidates = [
+    creator?.creator?.channelId,
+    creator?.creator?.channel_id,
+    creator?.channelId,
+    creator?.channel_id,
+    creator?.creator?.id,
+    creator?.creator?.channel?.id,
+    creator?.channel?.id,
+    creator?.video?.channel?.id,
+  ];
+
+  if (channelIdCandidates.some((value) => typeof value === 'string' && value.trim().length > 0)) {
+    return true;
+  }
+
+  const handleCandidates = [
+    creator?.creator?.handle,
+    creator?.creator?.username,
+    creator?.creator?.uniqueId,
+    creator?.handle,
+    creator?.username,
+    creator?.video?.channel?.handle,
+    creator?.channel?.handle,
+  ];
+
+  if (
+    handleCandidates.some((value) => typeof value === 'string' && value.trim().startsWith('@'))
+  ) {
+    return true;
+  }
+
+  const videoUrl = creator?.video?.url;
+  if (typeof videoUrl === 'string') {
+    const normalized = videoUrl.toLowerCase();
+    if (normalized.includes('youtube.com') || normalized.includes('youtu.be')) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasInstagramIndicators(creator: any): boolean {
+  const urlCandidates = [
+    creator?.creator?.profileUrl,
+    creator?.creator?.profile_url,
+    creator?.profileUrl,
+    creator?.profile_url,
+    creator?.video?.url,
+  ];
+
+  return urlCandidates.some((value) =>
+    typeof value === 'string' && value.toLowerCase().includes('instagram.com'),
+  );
+}
+
+function hasTikTokIndicators(creator: any): boolean {
+  const uniqueIdCandidates = [
+    creator?.creator?.uniqueId,
+    creator?.creator?.unique_id,
+    creator?.creator?.secUid,
+    creator?.creator?.sec_uid,
+    creator?.uniqueId,
+    creator?.unique_id,
+  ];
+
+  if (uniqueIdCandidates.some((value) => typeof value === 'string' && value.trim().length > 0)) {
+    return true;
+  }
+
+  const videoUrl = creator?.video?.url;
+  if (typeof videoUrl === 'string') {
+    return videoUrl.toLowerCase().includes('tiktok.com');
+  }
+
+  return false;
+}
+
+function resolvePlatform(creator: any, platformHint: string | null): 'youtube' | 'instagram' | 'tiktok' | null {
+  const candidates: Array<unknown> = [
+    creator?.platform,
+    creator?.creator?.platform,
+    creator?.sourcePlatform,
+    creator?.creator?.sourcePlatform,
+    creator?.metadata?.platform,
+    creator?.profile?.platform,
+    creator?.account?.platform,
+    platformHint,
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizePlatformValue(candidate);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  if (hasYouTubeIndicators(creator)) return 'youtube';
+  if (hasInstagramIndicators(creator)) return 'instagram';
+  if (hasTikTokIndicators(creator)) return 'tiktok';
+
+  return normalizePlatformValue(platformHint);
+}
+
 function firstNonEmpty(values: Array<unknown>): string | null {
   for (const value of values) {
     if (typeof value === 'string') {
@@ -139,18 +267,30 @@ function buildYouTubeLink(creator: any): string | null {
 }
 
 export function buildProfileLink(creator: any, platform: string): string {
-  const normalizedPlatform = (platform ?? '').toString().toLowerCase();
+  const normalizedPlatform = resolvePlatform(creator, platform ?? null);
 
   if (normalizedPlatform === 'tiktok') {
     return buildTikTokLink(creator) ?? '#';
   }
 
-  if (normalizedPlatform === 'instagram' || normalizedPlatform === 'enhanced-instagram') {
+  if (normalizedPlatform === 'instagram') {
     return buildInstagramLink(creator) ?? '#';
   }
 
   if (normalizedPlatform === 'youtube') {
     return buildYouTubeLink(creator) ?? '#';
+  }
+
+  if (hasYouTubeIndicators(creator)) {
+    return buildYouTubeLink(creator) ?? '#';
+  }
+
+  if (hasInstagramIndicators(creator)) {
+    return buildInstagramLink(creator) ?? '#';
+  }
+
+  if (hasTikTokIndicators(creator)) {
+    return buildTikTokLink(creator) ?? '#';
   }
 
   return '#';

--- a/test-scripts/ui/profile-link.test.ts
+++ b/test-scripts/ui/profile-link.test.ts
@@ -33,6 +33,16 @@ function expectEqual(actual: unknown, expected: unknown, message: string) {
     video: { url: 'https://www.youtube.com/watch?v=abcdef' }
   };
 
+  const youtubeCreatorWithIncorrectHint = {
+    platform: 'YouTube',
+    creator: {
+      name: 'Signal Boost',
+      channelId: 'UC999999999',
+      handle: '@signalboost'
+    },
+    video: { url: 'https://www.youtube.com/watch?v=hybrid' }
+  };
+
   const tiktokCreator = {
     creator: {
       uniqueId: 'dancequeen',
@@ -56,6 +66,12 @@ function expectEqual(actual: unknown, expected: unknown, message: string) {
     buildProfileLink(youtubeCreatorWithOnlyVideo, 'youtube'),
     'https://www.youtube.com/watch?v=abcdef',
     'YouTube link should fall back to video URL when no channel metadata'
+  );
+
+  expectEqual(
+    buildProfileLink(youtubeCreatorWithIncorrectHint, 'tiktok'),
+    'https://www.youtube.com/channel/UC999999999',
+    'YouTube link should override incorrect platform hints when creator metadata is authoritative'
   );
 
   expectEqual(


### PR DESCRIPTION
## Summary
- add platform-aware heuristics to the keyword search profile link builder so creator metadata takes precedence over request hints
- extend the profile link unit script to cover overrides when YouTube creators are mislabeled as other platforms

## Testing
- yes | npx tsx test-scripts/ui/profile-link.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68daab0cb0ac832fb10f6bd536383e0c