### PR TITLE
Allow unlimited onboarding brand descriptions

### DIFF
--- a/app/api/onboarding/step-2/route.ts
+++ b/app/api/onboarding/step-2/route.ts
@@ -21,12 +21,11 @@ export async function PATCH(request: Request) {
     }
 
     const { brandDescription } = await request.json();
-    console.log('📥 [ONBOARDING-STEP2] Data received:', { 
+    console.log('📥 [ONBOARDING-STEP2] Data received:', {
       brandDescription: brandDescription || 'NOT_PROVIDED',
       brandDescriptionLength: brandDescription?.length || 0,
       userId,
-      requestId,
-      meetsMinLength: (brandDescription?.length || 0) >= 50
+      requestId
     });
     
     console.log('📝 [ONBOARDING-STEP2] Brand description preview:', 
@@ -35,12 +34,6 @@ export async function PATCH(request: Request) {
     if (!brandDescription?.trim()) {
       return NextResponse.json({ 
         error: 'Brand description is required' 
-      }, { status: 400 });
-    }
-
-    if (brandDescription.trim().length < 50) {
-      return NextResponse.json({ 
-        error: 'Please provide more details (at least 50 characters)' 
       }, { status: 400 });
     }
 

--- a/app/components/onboarding/onboarding-modal.tsx
+++ b/app/components/onboarding/onboarding-modal.tsx
@@ -163,8 +163,7 @@ export default function OnboardingModal({
   const handleStep2Submit = async () => {
     await OnboardingLogger.logStep2('FORM-VALIDATION', 'Starting step 2 form validation', user?.id, {
       brandDescriptionProvided: !!brandDescription.trim(),
-      brandDescriptionLength: brandDescription.length,
-      meetsMinLength: brandDescription.trim().length >= 50
+      brandDescriptionLength: brandDescription.length
     }, sessionId);
 
     if (!brandDescription.trim()) {
@@ -172,16 +171,6 @@ export default function OnboardingModal({
         error: 'MISSING_BRAND_DESCRIPTION'
       }, sessionId);
       setError('Please describe your brand and influencer preferences');
-      return;
-    }
-
-    if (brandDescription.trim().length < 50) {
-      await OnboardingLogger.logStep2('VALIDATION-ERROR', 'Step 2 validation failed - brand description too short', user?.id, {
-        error: 'DESCRIPTION_TOO_SHORT',
-        currentLength: brandDescription.trim().length,
-        requiredLength: 50
-      }, sessionId);
-      setError('Please provide more details (at least 50 characters)');
       return;
     }
 
@@ -509,9 +498,7 @@ export default function OnboardingModal({
                       className="min-h-[120px] text-base resize-none bg-zinc-800/50 border-zinc-700/50 focus:border-primary"
                       disabled={isLoading}
                     />
-                    <div className="absolute bottom-2 right-2 text-xs text-zinc-400">
-                      {brandDescription.length}/500
-                    </div>
+      
                   </div>
 
                   <div className="flex items-start gap-2 p-3 bg-zinc-800/30 border border-zinc-700/50 rounded-lg">
@@ -556,7 +543,7 @@ export default function OnboardingModal({
                 <Button
                   onClick={handleStep2Submit}
                   className="w-full h-12 text-base bg-primary hover:bg-primary/90 text-primary-foreground"
-                  disabled={isLoading || brandDescription.trim().length < 50}
+                  disabled={isLoading || !brandDescription.trim()}
                 >
                   {isLoading ? (
                     <div className="flex items-center gap-2">
@@ -571,11 +558,6 @@ export default function OnboardingModal({
                   )}
                 </Button>
 
-                {brandDescription.trim().length < 50 && brandDescription.trim().length > 0 && (
-                  <p className="text-sm text-amber-400 text-center">
-                    Please provide more details (at least 50 characters) for better AI recommendations
-                  </p>
-                )}
               </CardContent>
             </>
           )}

--- a/app/onboarding/step-2/page.tsx
+++ b/app/onboarding/step-2/page.tsx
@@ -68,7 +68,7 @@ export default function OnboardingStep2() {
       descriptionLength: brandDescription.length,
       userId,
       userEmail: user?.primaryEmailAddress?.emailAddress,
-      meetsMinLength: brandDescription.trim().length >= 50
+      hasDescription: !!brandDescription.trim()
     });
     
     // Form validation - empty description
@@ -87,29 +87,6 @@ export default function OnboardingStep2() {
         userId,
         userEmail: user?.primaryEmailAddress?.emailAddress,
         validationType: 'empty_description'
-      });
-      
-      setError(validationError);
-      return;
-    }
-
-    // Form validation - too short
-    if (brandDescription.trim().length < 50) {
-      const validationError = 'Please provide more details (at least 50 characters)';
-      
-      logFormAction('step-2-form', 'validation', {
-        error: validationError,
-        descriptionLength: brandDescription.trim().length,
-        requiredLength: 50,
-        formComplete: false
-      });
-      
-      logError('form_validation', new Error(validationError), {
-        step: 'step-2',
-        userId,
-        userEmail: user?.primaryEmailAddress?.emailAddress,
-        validationType: 'description_too_short',
-        actualLength: brandDescription.trim().length
       });
       
       setError(validationError);
@@ -290,9 +267,7 @@ export default function OnboardingStep2() {
                       logUserAction('form_input_change', {
                         field: 'brandDescription',
                         valueLength: newValue.length,
-                        hasValue: !!newValue.trim(),
-                        meetsMinLength: newValue.trim().length >= 50,
-                        charactersRemaining: Math.max(0, 50 - newValue.trim().length)
+                        hasValue: !!newValue.trim()
                       }, {
                         userId,
                         userEmail: user?.primaryEmailAddress?.emailAddress,
@@ -313,7 +288,7 @@ export default function OnboardingStep2() {
                       logUserAction('form_field_blur', {
                         field: 'brandDescription',
                         finalLength: brandDescription.length,
-                        isValid: brandDescription.trim().length >= 50,
+                        hasContent: !!brandDescription.trim(),
                         descriptionPreview: brandDescription.trim().substring(0, 100) + (brandDescription.length > 100 ? '...' : '')
                       }, {
                         userId,
@@ -325,9 +300,6 @@ export default function OnboardingStep2() {
                     disabled={isLoading}
                     required
                   />
-                  <div className="absolute bottom-2 right-2 text-xs text-gray-400">
-                    {brandDescription.length}/500
-                  </div>
                 </div>
 
                 <div className="flex items-start gap-2 p-3 bg-zinc-800/60 border border-zinc-700/50 rounded-lg">
@@ -381,7 +353,7 @@ export default function OnboardingStep2() {
               <Button
                 type="submit"
                 className="w-full h-12 text-base font-semibold bg-pink-600 hover:bg-pink-500 text-white"
-                disabled={isLoading || brandDescription.trim().length < 50}
+                disabled={isLoading || !brandDescription.trim()}
               >
                 {isLoading ? (
                   <div className="flex items-center gap-2">
@@ -395,12 +367,6 @@ export default function OnboardingStep2() {
                   </div>
                 )}
               </Button>
-
-              {brandDescription.trim().length < 50 && brandDescription.trim().length > 0 && (
-                <p className="text-sm text-pink-400 text-center">
-                  Please provide more details (at least 50 characters) for better AI recommendations
-                </p>
-              )}
             </form>
 
             <div className="mt-6 p-4 bg-zinc-800/60 border border-zinc-700/50 rounded-lg">


### PR DESCRIPTION
## Summary
- remove the onboarding step 2 minimum-length gate so any non-empty description is accepted
- drop the 500-character counter and related instrumentation in both standalone and modal onboarding flows
- keep server-side validation aligned by allowing arbitrary description lengths while still trimming/saving safely

## Testing
- npm run lint

## UI Screenshots
![Onboarding Step 2 allows any length description](browser:/invocations/xbeoftxh/artifacts/artifacts/onboarding-step-2.png)

## Repro Steps
1. Start the onboarding flow and navigate to step 2.
2. Enter a very short or very long brand description.
3. Submit the form and observe it succeeds without length errors.

## Linked Issues
- N/A

## Migration Notes
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68e1367daf90832fb232978115db2c3c